### PR TITLE
feat: use Python 3.10 to run the checks

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -30,6 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"        
+
       - name: Spell Check
         id: spellcheck-step
         if: success() || failure()


### PR DESCRIPTION
This commit uses the `setup-python` action to provision Python 3.10 on the runner before running the checks. The choice of which specific version to use is kind of arbitrary, but 3.10 is the default version on the most recent LTS release of Ubuntu so it's probably a good target.