### PR TITLE
feat: use pa11y for accessibility checks

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -22,6 +22,9 @@ on:
       linkcheck-result:
         description: "Result of the link check"
         value: ${{ jobs.docchecks.outputs.result_links }}
+      pa11y-result:
+          description: "Result of the pa11y check"
+          value: ${{ jobs.docchecks.outputs.result_pa11y }}
 
 jobs:
   docchecks:
@@ -31,6 +34,7 @@ jobs:
       result_spelling: ${{ steps.spellcheck-step.outcome }}
       result_woke: ${{ steps.woke-step.outcome }}
       result_links: ${{ steps.linkcheck-step.outcome }}
+      result_pa11y: ${{ steps.pa11y-step.outcome }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,5 +62,13 @@ jobs:
         id: linkcheck-step
         if: success() || failure()
         uses: canonical/documentation-workflows/linkcheck@main
+        with:
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Accessibility Check
+        id: pa11y-step
+        continue-on-error: true
+        if: success() || failure()
+        uses: canonical/documentation-workflows/pa11y@main
         with:
           working-directory: ${{ inputs.working-directory }}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ This repository contains a collection of GitHub Actions and workflows designed t
 To be able to use the workflow, your repository must have a Makefile (at the location specified by `working-directory`) that defines the following targets:
 
 - `make install` - install the tools needed for all checks
-- `make woke` - run the inclusive language check
+- `make woke` - run the inclusive language check with [woke](https://github.com/get-woke/woke)
 - `make linkcheck` - run the link validator
 - `make spelling` - run the spelling check
+- `make pa11y` - run the accessibility check with [pa11y](https://pa11y.org)
 
 ## Using the Reusable Workflow
 

--- a/pa11y/action.yaml
+++ b/pa11y/action.yaml
@@ -1,0 +1,12 @@
+name: 'Accessibility check'
+description: 'Runs pa11y against the documentation'
+inputs:
+  working-directory:
+    description: 'Working directory'
+    required: true
+    default: '.'
+runs:
+  using: 'composite'
+  steps:
+    - run: python3 $GITHUB_ACTION_PATH/pa11y.py ${{ inputs.working-directory }}
+      shell: bash

--- a/pa11y/pa11y.py
+++ b/pa11y/pa11y.py
@@ -1,0 +1,15 @@
+import sys
+import subprocess
+
+def run_command(command, cwd):
+    subprocess.run(command, check=True, shell=True, cwd=cwd)
+
+working_directory = sys.argv[1]
+
+try:
+    # Install the doc framework and run link checker
+    run_command('make install', working_directory)
+    run_command('make pa11y', working_directory)
+except subprocess.CalledProcessError as e:
+    print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
+    exit(1)


### PR DESCRIPTION
This was ultimately triggered by canonical/sphinx-docs-starter-pack#28; the issue lists all stakeholders. As suggested there, this PR adds the accessibility check currently implemented as canonical/sphinx-docs-starter-pack#156 into the general documentation workflow.

Earlier, documentation checks were factored out from https://github.com/canonical/sphinx-docs-starter-pack/ into https://github.com/canonical/documentation-workflows/ for reuse. 