### PR TITLE
feat: fall back to starter pack Makefile

### DIFF
--- a/inclusive-language/inclusive_language.py
+++ b/inclusive-language/inclusive_language.py
@@ -9,13 +9,13 @@ working_directory = sys.argv[1]
 
 try:
     # If the starter pack Makefile is available, use it
-    makefile = "Makefile"
+    makefile, prefix = "Makefile", ""
     if os.path.exists(os.path.join(working_directory, "Makefile.sp")):
-        makefile = "Makefile.sp"
+        makefile, prefix = "Makefile.sp", "sp-"
 
     # Install the doc framework and run inclusive-language checker
-    run_command(f"make -f {makefile} install", working_directory)
-    run_command(f"make -f {makefile} woke", working_directory)
+    run_command(f"make -f {makefile} {prefix}install", working_directory)
+    run_command(f"make -f {makefile} {prefix}woke", working_directory)
 except subprocess.CalledProcessError as e:
     print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
     exit(1)

--- a/linkcheck/linkcheck.py
+++ b/linkcheck/linkcheck.py
@@ -9,13 +9,13 @@ working_directory = sys.argv[1]
 
 try:
     # If the starter pack Makefile is available, use it
-    makefile = "Makefile"
+    makefile, prefix = "Makefile", ""
     if os.path.exists(os.path.join(working_directory, "Makefile.sp")):
-        makefile = "Makefile.sp"
+        makefile, prefix = "Makefile.sp", "sp-"
 
     # Install the doc framework and run link checker
-    run_command(f"make -f {makefile} install", working_directory)
-    run_command(f"make -f {makefile} linkcheck", working_directory)
+    run_command(f"make -f {makefile} {prefix}install", working_directory)
+    run_command(f"make -f {makefile} {prefix}linkcheck", working_directory)
 except subprocess.CalledProcessError as e:
     print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
     exit(1)

--- a/pa11y/pa11y.py
+++ b/pa11y/pa11y.py
@@ -9,13 +9,13 @@ working_directory = sys.argv[1]
 
 try:
     # If the starter pack Makefile is available, use it
-    makefile = "Makefile"
+    makefile, prefix = "Makefile", ""
     if os.path.exists(os.path.join(working_directory, "Makefile.sp")):
-        makefile = "Makefile.sp"
+        makefile, prefix = "Makefile.sp", "sp-"
 
     # Install the doc framework and run link checker
-    run_command(f"make -f {makefile} install", working_directory)
-    run_command(f"make -f {makefile} pa11y", working_directory)
+    run_command(f"make -f {makefile} {prefix}install", working_directory)
+    run_command(f"make -f {makefile} {prefix}pa11y", working_directory)
 except subprocess.CalledProcessError as e:
     print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
     exit(1)

--- a/spellcheck/spellcheck.py
+++ b/spellcheck/spellcheck.py
@@ -12,13 +12,13 @@ try:
     run_command('sudo apt-get install aspell aspell-en', working_directory)
 
     # If the starter pack Makefile is available, use it
-    makefile = "Makefile"
+    makefile, prefix = "Makefile", ""
     if os.path.exists(os.path.join(working_directory, "Makefile.sp")):
-        makefile = "Makefile.sp"
+        makefile, prefix = "Makefile.sp", "sp-"
 
     # Install the doc framework and run spelling checker
-    run_command(f"make -f {makefile} install", working_directory)
-    run_command(f"make -f {makefile} spelling", working_directory)
+    run_command(f"make -f {makefile} {prefix}install", working_directory)
+    run_command(f"make -f {makefile} {prefix}spelling", working_directory)
 except subprocess.CalledProcessError as e:
     print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
     exit(1)


### PR DESCRIPTION
This builds on the work happening under canonical/sphinx-docs-starter-pack#101 to seamlessly integrate the new version of the Makefile with the old without breaking too much CI glassware in the process; the idea is to use the more specific SP-related file if it's available.