### PR TITLE
Update github actions used in documentation-checks.yaml

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -29,7 +29,7 @@ on:
 jobs:
   docchecks:
     name: Run documentation checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       result_spelling: ${{ steps.spellcheck-step.outcome }}
       result_woke: ${{ steps.woke-step.outcome }}
@@ -37,10 +37,10 @@ jobs:
       result_pa11y: ${{ steps.pa11y-step.outcome }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
The current github action versions used for documentation-checks is throwing warnings due to the node.js version used.
I've updated the pointers to the latest versions; they are working fine without errors now.

Example workflow. It's failing the actual spellcheck instead of throwing warnings about the github action.
https://github.com/canonical/kernel-factory-docs/actions/runs/9476187989

Thanks!