### PR TITLE
pre-install woke

### DIFF
--- a/inclusive-language/inclusive_language.py
+++ b/inclusive-language/inclusive_language.py
@@ -18,6 +18,9 @@ woke_target = args.woke_target
 makefile = args.makefile
 
 try:
+    # Install Woke
+    run_command('sudo snap install woke', args.working_dir)
+
     # If the Makefile has not been specified, use the starter pack Makefile (and the corresponding
     # targets) if available. Otherwise, use "Makefile".
     if makefile == "use-default":


### PR DESCRIPTION
Done as a counterpart to mandatory installation
in `spellcheck/spellcheck.py`.

This fixes the build in canonical/sphinx-docs-starter-pack#291