### PR TITLE
drop forced install in favour of Makefile way

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -80,7 +80,6 @@ jobs:
         uses: canonical/documentation-workflows/spellcheck@main
         with:
           working-directory: ${{ inputs.working-directory }}
-          install-target: ${{ inputs.install-target }}
           spelling-target: ${{ inputs.spelling-target }}
           makefile: ${{ inputs.makefile }}
 
@@ -90,7 +89,6 @@ jobs:
         uses: canonical/documentation-workflows/inclusive-language@main
         with:
           working-directory: ${{ inputs.working-directory }}
-          install-target: ${{ inputs.install-target }}
           woke-target: ${{ inputs.woke-target }}
           makefile: ${{ inputs.makefile }}
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To be able to use the workflow, your repository must have a Makefile (at the loc
 - `make spelling` - run the spelling check
 - `make pa11y` - run the accessibility check with [pa11y](https://pa11y.org)
 
+It must also accept a `CONFIRM_SUDO=y` option to install `woke` and `aspell` using `sudo` privileges if needed.
+
 ## Using the Reusable Workflow
 
 To use the `documentation-checks.yml` workflow in another repository, create a new workflow and reference it using the `uses` directive. Here's a basic example:

--- a/inclusive-language/action.yaml
+++ b/inclusive-language/action.yaml
@@ -23,5 +23,5 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: python3 $GITHUB_ACTION_PATH/inclusive_language.py ${{ inputs.working-directory }} --install_target ${{ inputs.install-target }} --woke_target ${{ inputs.woke-target }} --makefile ${{ inputs.makefile }}
+    - run: python3 $GITHUB_ACTION_PATH/inclusive_language.py ${{ inputs.working-directory }} --woke_target ${{ inputs.woke-target }} --makefile ${{ inputs.makefile }}
       shell: bash

--- a/inclusive-language/inclusive_language.py
+++ b/inclusive-language/inclusive_language.py
@@ -8,32 +8,25 @@ def run_command(command, cwd):
 
 parser = argparse.ArgumentParser()
 parser.add_argument("working_dir")
-parser.add_argument("--install_target")
 parser.add_argument("--woke_target")
 parser.add_argument("--makefile")
 args = parser.parse_args()
 
-install_target = args.install_target
 woke_target = args.woke_target
 makefile = args.makefile
 
 try:
-    # Install Woke
-    run_command('sudo snap install woke', args.working_dir)
-
     # If the Makefile has not been specified, use the starter pack Makefile (and the corresponding
     # targets) if available. Otherwise, use "Makefile".
     if makefile == "use-default":
         if os.path.exists(os.path.join(args.working_dir, "Makefile.sp")):
             makefile = "Makefile.sp"
-            install_target = "sp-" + install_target
             woke_target = "sp-" + woke_target
         else:
             makefile = "Makefile"
 
     # Install the doc framework and run inclusive-language checker
-    run_command(f"make -f {makefile} {install_target}", args.working_dir)
-    run_command(f"make -f {makefile} {woke_target}", args.working_dir)
+    run_command(f"make -f {makefile} {woke_target} CONFIRM_SUDO=y", args.working_dir)
 except subprocess.CalledProcessError as e:
     print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
     exit(1)

--- a/spellcheck/action.yaml
+++ b/spellcheck/action.yaml
@@ -23,5 +23,5 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: python3 $GITHUB_ACTION_PATH/spellcheck.py ${{ inputs.working-directory }} --install_target ${{ inputs.install-target }} --spelling_target ${{ inputs.spelling-target }} --makefile ${{ inputs.makefile }}
+    - run: python3 $GITHUB_ACTION_PATH/spellcheck.py ${{ inputs.working-directory }} --spelling_target ${{ inputs.spelling-target }} --makefile ${{ inputs.makefile }}
       shell: bash

--- a/spellcheck/spellcheck.py
+++ b/spellcheck/spellcheck.py
@@ -7,32 +7,25 @@ def run_command(command, cwd):
     subprocess.run(command, check=True, shell=True, cwd=cwd)
 parser = argparse.ArgumentParser()
 parser.add_argument("working_dir")
-parser.add_argument("--install_target")
 parser.add_argument("--spelling_target")
 parser.add_argument("--makefile")
 args = parser.parse_args()
 
-install_target = args.install_target
 spelling_target = args.spelling_target
 makefile = args.makefile
 
 try:
-    # Install Aspell
-    run_command('sudo apt-get install aspell aspell-en', args.working_dir)
-
     # If the Makefile has not been specified, use the starter pack Makefile (and the corresponding
     # targets) if available. Otherwise, use "Makefile".
     if makefile == "use-default":
         if os.path.exists(os.path.join(args.working_dir, "Makefile.sp")):
             makefile = "Makefile.sp"
-            install_target = "sp-" + install_target
             spelling_target = "sp-" + spelling_target
         else:
             makefile = "Makefile"
 
     # Install the doc framework and run spelling checker
-    run_command(f"make -f {makefile} {install_target}", args.working_dir)
-    run_command(f"make -f {makefile} {spelling_target}", args.working_dir)
+    run_command(f"make -f {makefile} {spelling_target} CONFIRM_SUDO=y", args.working_dir)
 except subprocess.CalledProcessError as e:
     print(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.")
     exit(1)


### PR DESCRIPTION
This installs system tools using the Makefile, not explicitly, and invokes only the targets needed for what's actually tested.

The issue was raised in canonical/documentation-workflows#20.