### PR TITLE
Changed runs-on to use self-hosted runers

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -59,7 +59,7 @@ on:
 jobs:
   docchecks:
     name: Run documentation checks
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, amd64, noble ]
     outputs:
       result_spelling: ${{ steps.spellcheck-step.outcome }}
       result_woke: ${{ steps.woke-step.outcome }}


### PR DESCRIPTION
This PR will move all repos using this repo use the Canonical-hosted GH runners. This is tested (and works) with two repos: canonical/information-systems-documentation and canonical/information-systems-internal-documentation.

When merging this, ensure that there is communication around the change (e.g. a discours post), and that there are staff available that can react if things go south (e.g. fix problems, give support or revert the change. Feel free to coordinate with me.