### PR TITLE
ci: add separate workflows for each check

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -47,82 +47,51 @@ on:
         required: false
         type: string
         default: '["ubuntu-24.04"]'
-      pa11y-target:
-        description: 'Target to run for the accessibility check (default: "pa11y")'
-        required: false
-        type: string
-        default: 'pa11y'
+
     outputs:
       spellcheck-result:
         description: "Result of the spelling check"
-        value: ${{ jobs.docchecks.outputs.result_spelling }}
+        value: ${{ jobs.spellcheck.outputs.result }}
       woke-result:
         description: "Result of the inclusive language check"
-        value: ${{ jobs.docchecks.outputs.result_woke }}
+        value: ${{ jobs.inclusive-language.outputs.result }}
       linkcheck-result:
         description: "Result of the link check"
-        value: ${{ jobs.docchecks.outputs.result_links }}
-      # pa11y-result:
-      #     description: "Result of the pa11y check"
-      #     value: ${{ jobs.docchecks.outputs.result_pa11y }}
+        value: ${{ jobs.linkcheck.outputs.result }}
 
 jobs:
-  docchecks:
-    name: Run documentation checks
-    runs-on: ${{ fromJson(inputs.runs-on) }}
-    outputs:
-      result_spelling: ${{ steps.spellcheck-step.outcome }}
-      result_woke: ${{ steps.woke-step.outcome }}
-      result_links: ${{ steps.linkcheck-step.outcome }}
-      # result_pa11y: ${{ steps.pa11y-step.outcome }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ inputs.fetch-depth }}
+  spellcheck:
+    name: Spell check
+    uses: ./.github/workflows/spell-check.yaml
+    with:
+      working-directory: ${{ inputs.working-directory }}
+      python-version: ${{ inputs.python-version }}
+      install-target: ${{ inputs.install-target }}
+      spelling-target: ${{ inputs.spelling-target }}
+      makefile: ${{ inputs.makefile }}
+      fetch-depth: ${{ inputs.fetch-depth }}
+      runs-on: ${{ inputs.runs-on }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
+  inclusive-language:
+    name: Inclusive language check
+    uses: ./.github/workflows/inclusive-language-check.yaml
+    with:
+      working-directory: ${{ inputs.working-directory }}
+      python-version: ${{ inputs.python-version }}
+      install-target: ${{ inputs.install-target }}
+      woke-target: ${{ inputs.woke-target }}
+      makefile: ${{ inputs.makefile }}
+      fetch-depth: ${{ inputs.fetch-depth }}
+      runs-on: ${{ inputs.runs-on }}
 
-      - name: Spell Check
-        id: spellcheck-step
-        if: success() || failure()
-        uses: canonical/documentation-workflows/spellcheck@main
-        with:
-          working-directory: ${{ inputs.working-directory }}
-          install-target: ${{ inputs.install-target }}
-          spelling-target: ${{ inputs.spelling-target }}
-          makefile: ${{ inputs.makefile }}
-
-      - name: Inclusive Language Check
-        id: woke-step
-        if: success() || failure()
-        uses: canonical/documentation-workflows/inclusive-language@main
-        with:
-          working-directory: ${{ inputs.working-directory }}
-          install-target: ${{ inputs.install-target }}
-          woke-target: ${{ inputs.woke-target }}
-          makefile: ${{ inputs.makefile }}
-
-      - name: Link Check
-        id: linkcheck-step
-        if: success() || failure()
-        uses: canonical/documentation-workflows/linkcheck@main
-        with:
-          working-directory: ${{ inputs.working-directory }}
-          install-target: ${{ inputs.install-target }}
-          linkcheck-target: ${{ inputs.linkcheck-target }}
-          makefile: ${{ inputs.makefile }}
-
-      # - name: Accessibility Check
-      #   id: pa11y-step
-      #   continue-on-error: true
-      #   if: success() || failure()
-      #   uses: canonical/documentation-workflows/pa11y@main
-      #   with:
-      #     working-directory: ${{ inputs.working-directory }}
-      #     install-target: ${{ inputs.install-target }}
-      #     pa11y-target: ${{ inputs.pa11y-target }}
-      #     makefile: ${{ inputs.makefile }}
+  linkcheck:
+    name: Link check
+    uses: ./.github/workflows/link-check.yaml
+    with:
+      working-directory: ${{ inputs.working-directory }}
+      python-version: ${{ inputs.python-version }}
+      install-target: ${{ inputs.install-target }}
+      linkcheck-target: ${{ inputs.linkcheck-target }}
+      makefile: ${{ inputs.makefile }}
+      fetch-depth: ${{ inputs.fetch-depth }}
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -62,7 +62,7 @@ on:
 jobs:
   spellcheck:
     name: Spell check
-    uses: ./.github/workflows/spell-check.yaml
+    uses: ./.github/workflows/spelling-check.yaml
     with:
       working-directory: ${{ inputs.working-directory }}
       python-version: ${{ inputs.python-version }}

--- a/.github/workflows/inclusive-language-check.yaml
+++ b/.github/workflows/inclusive-language-check.yaml
@@ -1,0 +1,70 @@
+name: Documentation inclusive language check
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Working directory'
+        required: true
+        type: string
+      python-version:
+        description: 'Version of the Python interpreter to use (defaults to 3.10)'
+        required: false
+        type: string
+        default: '3.10'
+      makefile:
+        description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
+        required: false
+        type: string
+        default: 'use-default'
+      install-target:
+        description: 'Target to run to install the tools (default: "install")'
+        required: false
+        type: string
+        default: 'install'
+      woke-target:
+        description: 'Target to run for the inclusive language check (default: "woke")'
+        required: false
+        type: string
+        default: 'woke'
+      fetch-depth:
+        description: 'Fetch depth to support timestamps'
+        required: false
+        type: string
+        default: '0'
+      runs-on:
+        description: 'GitHub runners'
+        required: false
+        type: string
+        default: '["ubuntu-24.04"]'
+    outputs:
+      result:
+        description: "Result of the inclusive language check"
+        value: ${{ jobs.woke.outputs.result }}
+
+jobs:
+  woke:
+    name: Check for inclusive language in the documentation
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+    outputs:
+      result: ${{ steps.woke-step.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Inclusive Language Check
+        id: woke-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/inclusive-language@main
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          install-target: ${{ inputs.install-target }}
+          woke-target: ${{ inputs.woke-target }}
+          makefile: ${{ inputs.makefile }}

--- a/.github/workflows/inclusive-language-check.yaml
+++ b/.github/workflows/inclusive-language-check.yaml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Inclusive Language Check
         id: woke-step
-        if: success() || failure()
         uses: canonical/documentation-workflows/inclusive-language@main
         with:
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,0 +1,70 @@
+name: Documentation link check
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Working directory'
+        required: true
+        type: string
+      python-version:
+        description: 'Version of the Python interpreter to use (defaults to 3.10)'
+        required: false
+        type: string
+        default: '3.10'
+      makefile:
+        description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
+        required: false
+        type: string
+        default: 'use-default'
+      install-target:
+        description: 'Target to run to install the tools (default: "install")'
+        required: false
+        type: string
+        default: 'install'
+      linkcheck-target:
+        description: 'Target to run for the link check (default: "linkcheck")'
+        required: false
+        type: string
+        default: 'linkcheck'
+      fetch-depth:
+        description: 'Fetch depth to support timestamps'
+        required: false
+        type: string
+        default: '0'
+      runs-on:
+        description: 'GitHub runners'
+        required: false
+        type: string
+        default: '["ubuntu-24.04"]'
+    outputs:
+      result:
+        description: "Result of the link check"
+        value: ${{ jobs.linkcheck.outputs.result }}
+
+jobs:
+  linkcheck:
+    name: Check links in the documentation
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+    outputs:
+      result: ${{ steps.linkcheck-step.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Link Check
+        id: linkcheck-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/linkcheck@main
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          install-target: ${{ inputs.install-target }}
+          linkcheck-target: ${{ inputs.linkcheck-target }}
+          makefile: ${{ inputs.makefile }}

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Link Check
         id: linkcheck-step
-        if: success() || failure()
         uses: canonical/documentation-workflows/linkcheck@main
         with:
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/spelling-check.yaml
+++ b/.github/workflows/spelling-check.yaml
@@ -1,0 +1,70 @@
+name: Documentation spelling check
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Working directory'
+        required: true
+        type: string
+      python-version:
+        description: 'Version of the Python interpreter to use (defaults to 3.10)'
+        required: false
+        type: string
+        default: '3.10'
+      makefile:
+        description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
+        required: false
+        type: string
+        default: 'use-default'
+      install-target:
+        description: 'Target to run to install the tools (default: "install")'
+        required: false
+        type: string
+        default: 'install'
+      spelling-target:
+        description: 'Target to run for the spelling check (default: "spelling")'
+        required: false
+        type: string
+        default: 'spelling'
+      fetch-depth:
+        description: 'Fetch depth to support timestamps'
+        required: false
+        type: string
+        default: '0'
+      runs-on:
+        description: 'GitHub runners'
+        required: false
+        type: string
+        default: '["ubuntu-24.04"]'
+    outputs:
+      spellcheck-result:
+        description: "Result of the spelling check"
+        value: ${{ jobs.spellcheck.outputs.result }}
+
+jobs:
+  spellcheck:
+    name: Check spelling in the documentation
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+    outputs:
+      result: ${{ steps.spellcheck-step.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Spell Check
+        id: spellcheck-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/spellcheck@main
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          install-target: ${{ inputs.install-target }}
+          spelling-target: ${{ inputs.spelling-target }}
+          makefile: ${{ inputs.makefile }}

--- a/.github/workflows/spelling-check.yaml
+++ b/.github/workflows/spelling-check.yaml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Spell Check
         id: spellcheck-step
-        if: success() || failure()
         uses: canonical/documentation-workflows/spellcheck@main
         with:
           working-directory: ${{ inputs.working-directory }}

--- a/README.md
+++ b/README.md
@@ -1,56 +1,80 @@
 # Documentation Workflows
 
-This repository contains a collection of GitHub Actions and workflows designed to automate various checks and processes related to documentation. These tools aim to ensure the quality, consistency, and accuracy of documentation across projects.
-
-## Overview
-
-- **GitHub Actions**: We have a set of individual actions that can be used in any workflow. These actions are designed to perform specific tasks such as spell checking, inclusive language checks, and link validation.
-  
-- **Reusable Workflows**: In addition to individual actions, this repository offers a top-level workflow (`documentation-checks.yaml`) that combines multiple checks. This workflow can be called from other repositories, providing a comprehensive documentation validation process in a single step.
+This repository contains composite actions and workflows that automate documentation
+quality checks.
 
 ## Requirements
 
-To be able to use the workflow, your repository must have a Makefile (at the location specified by `working-directory`) that defines the following targets:
+To use the workflows in your documentation project, it's recommended that you
+incorporate Canonical's [Sphinx Starter
+Pack](https://github.com/canonical/sphinx-docs-starter-pack). With the Starter Pack in
+place, you can use the workflows without overriding the default inputs or implementing
+the checks in your own Makefile.
 
-- `make install` - install the tools needed for all checks
-- `make woke` - run the inclusive language check with [woke](https://github.com/get-woke/woke)
-- `make linkcheck` - run the link validator
-- `make spelling` - run the spelling check
-- `make pa11y` - run the accessibility check with [pa11y](https://pa11y.org)
+## `documentation-checks.yaml`
 
-## Using the Reusable Workflow
+The primary documentation workflow checks spelling, links, and inclusive language in a
+documentation project.
 
-To use the `documentation-checks.yml` workflow in another repository, create a new workflow and reference it using the `uses` directive. Here's a basic example:
+### Usage
 
-```yaml
-name: Main Documentation Checks
-
-on:
-  - push
-  - pull_request
-
-jobs:
-  documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yml@main
-    with:
-      working-directory: '.'
-```
-
-By default, the workflow will run using Python 3.10. You can choose a different version of the interpreter with the `python-version` input variable. For example:
+If your project uses the Starter Pack, you can add the documentation checks to a new
+or existing workflow's jobs with:
 
 ```yaml
-...
-
 jobs:
+  [...]
   documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yml@main
+    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
     with:
-      working-directory: '.'
-      python-version: '3.12'
+      working-directory: 'docs'
 ```
 
-If you want to use a workflow version other than `main`, replace `@main` with the appropriate branch or tag.
+### Inputs
+
+If your project doesn't use the Starter Pack or consumes it in a non-traditional way,
+declare any of the following inputs to customize the workflow as needed:
+
+| Input               | Description                                                    | Default                         |
+|---------------------|----------------------------------------------------------------|---------------------------------|
+| `working-directory` | The root of the documentation project. This input is required. | None                            |
+| `python-version`    | The Python interpreter to use for the workflow's jobs.         | `'3.10'`                        |
+| `fetch-depth`       | The number of commits to fetch from your repository.           | The full history is fetched.    |
+| `runs-on`           | The host system for the workflow's runners.                    | `'["ubuntu-24.04"]'`            |
+| `makefile`          | The Makefile that checks are invoked from.                     | `'Makefile'`                    |
+| `install-target`    | The make target for installing required tools.                 | `'install'`                     |
+| `spelling-target`   | The make target to run for the spelling check.                 | `'spelling'`                    |
+| `woke-target`       | The make target to run for the inclusive language check.       | `'woke'`                        |
+| `linkcheck-target`  | The make target to run for the link check.                     | `'linkcheck'`                   |
+
+## Individual checks
+
+Workflows are also available for each individual check, so that projects may run a
+subset of those defined in `documentation-checks.yaml`. The following jobs are
+equivalent to the `documentation-checks` job from the previous example:
+
+```yaml
+jobs:
+  spell-check:
+    uses: canonical/documentation-workflows/.github/workflows/spelling-check.yaml@main
+    with:
+      working-directory: "docs"
+  inclusive-language-check:
+    uses: canonical/documentation-workflows/.github/workflows/inclusive-language-check.yaml@main
+    with:
+      working-directory: "docs"    
+  link-check:
+    uses: canonical/documentation-workflows/.github/workflows/link-check.yaml@main
+    with:
+      working-directory: "docs"
+```
+
+Each of these workflows supports the same inputs as `documentation-checks.yaml`, save
+the targets for the other checks. For example, the `link-check.yaml` workflow doesn't
+support the `spelling-target` or `woke-target` inputs.
 
 ## Contributing
 
-We welcome contributions to improve and expand the capabilities of this repository. If you have a new check or enhancement in mind, please open an issue to discuss it or submit a pull request.
+We welcome any and all contributions. For new features and enhancements, [open an
+issue](https://github.com/canonical/documentation-workflows/issues/new) and state that
+you'd like to take it on. A maintainer will then review the issue and assign it to you.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ declare any of the following inputs to customize the workflow as needed:
 
 ## Individual checks
 
-Workflows are also available for each individual check, so that projects may run a
-subset of those defined in `documentation-checks.yaml`. The following jobs are
-equivalent to the `documentation-checks` job from the previous example:
+Workflows are available for each individual check so that projects may run a subset of
+those defined in `documentation-checks.yaml`. The following jobs are equivalent to the
+`documentation-checks` job from the previous example:
 
 ```yaml
 jobs:


### PR DESCRIPTION
Resolves https://github.com/canonical/documentation-workflows/issues/18, https://github.com/canonical/documentation-workflows/issues/36, and https://github.com/canonical/documentation-workflows/issues/39.

[Rendered README](https://github.com/canonical/documentation-workflows/blob/work/split-workflows/README.md)

This PR adds separate workflows for each check, allowing downstream projects to customize their choice of workflows. These new workflows can be called with:

```
jobs:
  new-spellcheck:
    uses: canonical/documentation-workflows/.github/workflows/spelling-check.yaml@work/split-workflows
    with:
      working-directory: "src"

  new-woke-check:
    uses: canonical/documentation-workflows/.github/workflows/inclusive-language-check.yaml@work/split-workflows
    with:
      working-directory: "src"    

  new-linkcheck:
    uses: canonical/documentation-workflows/.github/workflows/link-check.yaml@work/split-workflows
    with:
      working-directory: "src"
```
The `documentation-checks.yaml` workflow now runs each of these as a separate job, which allows them to run concurrently, and be re-run individually in the event of a failure. This refactor is completely backwards compatible.

I've verified the functionality of the new workflows in a minimal docs repo [results](https://github.com/jahn-junior/mockumentation/actions/runs/21612880833).