### PR TITLE
Update python version for checks for compatibility

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -11,7 +11,7 @@ on:
         description: 'Version of the Python interpreter to use (defaults to 3.10)'
         required: false
         type: string
-        default: '3.10'
+        default: '3.12'
       makefile:
         description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
         required: false

--- a/.github/workflows/inclusive-language-check.yaml
+++ b/.github/workflows/inclusive-language-check.yaml
@@ -11,7 +11,7 @@ on:
         description: 'Version of the Python interpreter to use (defaults to 3.10)'
         required: false
         type: string
-        default: '3.10'
+        default: '3.12'
       makefile:
         description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
         required: false

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -11,7 +11,7 @@ on:
         description: 'Version of the Python interpreter to use (defaults to 3.10)'
         required: false
         type: string
-        default: '3.10'
+        default: '3.12'
       makefile:
         description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
         required: false

--- a/.github/workflows/spelling-check.yaml
+++ b/.github/workflows/spelling-check.yaml
@@ -11,7 +11,7 @@ on:
         description: 'Version of the Python interpreter to use (defaults to 3.10)'
         required: false
         type: string
-        default: '3.10'
+        default: '3.12'
       makefile:
         description: 'Name of the Makefile to use (default: "Makefile.sp" if it exists, "Makefile" otherwise)'
         required: false


### PR DESCRIPTION
Set python3.12 as default python version, fixing the compatibility issues with sphinx-autobuild==2025.8.25. Some examples:
https://github.com/canonical/falco-operators/actions/runs/22180485403/job/64140203561?pr=84
https://github.com/canonical/falco-operators/actions/runs/22180485403/job/64140203520?pr=84
https://github.com/canonical/falco-operators/actions/runs/22180485403/job/64140203516?pr=84