### PR TITLE
Add optional 'submodules' input to documentation check workflows

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: '0'
+      submodules:
+        description: 'Whether to checkout submodules when checking out the repository'
+        required: false
+        type: boolean
+        default: false
       runs-on:
         description: 'GitHub runners'
         required: false
@@ -70,6 +75,7 @@ jobs:
       spelling-target: ${{ inputs.spelling-target }}
       makefile: ${{ inputs.makefile }}
       fetch-depth: ${{ inputs.fetch-depth }}
+      submodules: ${{ inputs.submodules }}
       runs-on: ${{ inputs.runs-on }}
 
   inclusive-language:
@@ -82,6 +88,7 @@ jobs:
       woke-target: ${{ inputs.woke-target }}
       makefile: ${{ inputs.makefile }}
       fetch-depth: ${{ inputs.fetch-depth }}
+      submodules: ${{ inputs.submodules }}
       runs-on: ${{ inputs.runs-on }}
 
   linkcheck:
@@ -94,4 +101,5 @@ jobs:
       linkcheck-target: ${{ inputs.linkcheck-target }}
       makefile: ${{ inputs.makefile }}
       fetch-depth: ${{ inputs.fetch-depth }}
+      submodules: ${{ inputs.submodules }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/inclusive-language-check.yaml
+++ b/.github/workflows/inclusive-language-check.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: '0'
+      submodules:
+        description: 'Whether to checkout submodules when checking out the repository'
+        required: false
+        type: boolean
+        default: false
       runs-on:
         description: 'GitHub runners'
         required: false
@@ -53,6 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
+          submodules: ${{ inputs.submodules }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: '0'
+      submodules:
+        description: 'Whether to checkout submodules when checking out the repository'
+        required: false
+        type: boolean
+        default: false
       runs-on:
         description: 'GitHub runners'
         required: false
@@ -53,6 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
+          submodules: ${{ inputs.submodules }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/spelling-check.yaml
+++ b/.github/workflows/spelling-check.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: '0'
+      submodules:
+        description: 'Whether to checkout submodules when checking out the repository'
+        required: false
+        type: boolean
+        default: false
       runs-on:
         description: 'GitHub runners'
         required: false
@@ -53,6 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
+          submodules: ${{ inputs.submodules }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ declare any of the following inputs to customize the workflow as needed:
 | `working-directory` | The root of the documentation project. This input is required. | None                            |
 | `python-version`    | The Python interpreter to use for the workflow's jobs.         | `'3.10'`                        |
 | `fetch-depth`       | The number of commits to fetch from your repository.           | The full history is fetched.    |
+| `submodules`        | Whether to checkout submodules when checking out the repository. | `false`                         |
 | `runs-on`           | The host system for the workflow's runners.                    | `'["ubuntu-24.04"]'`            |
 | `makefile`          | The Makefile that checks are invoked from.                     | `'Makefile'`                    |
 | `install-target`    | The make target for installing required tools.                 | `'install'`                     |


### PR DESCRIPTION
Adds a `submodules` input (default: `false`) to all documentation check workflows. When set to `true`, submodules are checked out during the checkout step.

This is useful for documentation projects that use git submodules (e.g., for shared or nested documentation content).

Default behavior is unchanged.